### PR TITLE
Support Facter 1.7.x in spec tests

### DIFF
--- a/spec/unit/ldom_spec.rb
+++ b/spec/unit/ldom_spec.rb
@@ -15,7 +15,11 @@ DOMAINCHASSIS|serialno=0704RB0280"
 
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
     Facter::Util::Resolution.stubs(:exec).with("virtinfo -ap").returns(ldom_v1)
-    Facter.collection.loader.load(:ldom)
+    if Facter.collection.respond_to? :internal_loader
+      Facter.collection.internal_loader.load(:ldom) # Facter >= 1.7.x
+    else
+      Facter.collection.loader.load(:ldom) # Facter < 1.7.x
+    end
   end
 
   # http://docs.oracle.com/cd/E23824_01/html/821-1462/virtinfo-1m.html


### PR DESCRIPTION
The facter project has renamed `loader` into `internal_loader` which
breaks the ldom spec test. The ldom fact needs to be explicitly loaded
by facter because the autoloader cannot find it (the facts are named
different than the filename they are stored in).

Use internal_loader when available otherwise suppose we are on facter <
1.6.x and use loader.

For reference: The change that caused the spec failures was introduced
in commit 082dba6 of the facter project.
