### PR TITLE
Fix zonename fact

### DIFF
--- a/spec/unit/zonename_spec.rb
+++ b/spec/unit/zonename_spec.rb
@@ -7,8 +7,13 @@ describe "zonename fact" do
 
   it "should return global zone" do
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    Facter::Util::Resolution.stubs(:exec).with("zonename").returns('global')
 
-    Facter.fact(:zonename).value.should == "global"
+    if defined?(Facter::Core)
+      Facter::Core::Execution.expects(:execute).with("zonename", {:on_fail => nil}).returns('global')
+    else
+      Facter::Util::Resolution.stubs(:exec).with("zonename").returns('global')
+    end
+
+    Facter.value(:zonename).should == "global"
   end
 end


### PR DESCRIPTION
The zonename fact uses a simple resolution of `setcode("zonename")`. This
creates different resolvers on facter < 2 and facter >= 2. In facter 2
this is delegated to a new module Facter::Core so change the expectation
accordingly
