### PR TITLE
Always refresh services after changes

### DIFF
--- a/lib/puppet/provider/service_config/svccfg.rb
+++ b/lib/puppet/provider/service_config/svccfg.rb
@@ -3,6 +3,7 @@ Puppet::Type.type(:service_config).provide(:svccfg) do
   desc "Manages smf configuration with svccfg"
 
   commands :svccfg => '/usr/sbin/svccfg'
+  commands :svcadm => '/usr/sbin/svcadm'
 
   defaultfor :operatingsystem => :solaris
 
@@ -51,4 +52,7 @@ Puppet::Type.type(:service_config).provide(:svccfg) do
     end
   end
 
+  def flush
+    svcadm(:refresh, resource[:fmri])
+  end
 end

--- a/spec/integration/provider/service_config/svccfg_spec.rb
+++ b/spec/integration/provider/service_config/svccfg_spec.rb
@@ -53,24 +53,28 @@ describe Puppet::Type.type(:service_config).provider(:svccfg), '(integration)' d
     it "should do nothing if value is in sync" do
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring example.com\n")
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"example.com"').never
+      resource_singlevalue.provider.expects(:svcadm).with(:refresh, fmri).never
       run_in_catalog(resource_singlevalue)
     end
 
     it "should create the property if currently absent" do
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("\n\n")
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"example.com"')
+      resource_singlevalue.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_singlevalue)
     end
 
     it "should replace a single value" do
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring wrong.com\n")
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"example.com"')
+      resource_singlevalue.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_singlevalue)
     end
 
     it "should replace a list of values" do
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring \"example.com\" \"wrong.com\"\n")
       resource_singlevalue.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"example.com"')
+      resource_singlevalue.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_singlevalue)
     end
   end
@@ -79,24 +83,28 @@ describe Puppet::Type.type(:service_config).provider(:svccfg), '(integration)' d
     it "should do nothing if value is in sync" do
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring test.com\n")
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"test.com"').never
+      resource_listone.provider.expects(:svcadm).with(:refresh, fmri).never
       run_in_catalog(resource_listone)
     end
 
     it "should create the property if currently absent" do
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("\n\n")
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"test.com"')
+      resource_listone.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_listone)
     end
 
     it "should replace a single value" do
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring wrong.com\n")
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"test.com"')
+      resource_listone.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_listone)
     end
 
     it "should replace a list of values" do
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring \"example.com\" \"wrong.com\"\n")
       resource_listone.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '"test.com"')
+      resource_listone.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_listone)
     end
   end
@@ -105,43 +113,50 @@ describe Puppet::Type.type(:service_config).provider(:svccfg), '(integration)' d
     it "should do nothing if value is in sync" do
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring \"example.com\" \"example.de\" \"test.com\"\n")
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '("example.com" "example.de" "test.com")').never
+      resource_listthree.provider.expects(:svcadm).with(:refresh, fmri).never
       run_in_catalog(resource_listthree)
     end
 
     it "should create the property if currently absent" do
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("\n\n")
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '("example.com" "example.de" "test.com")')
+      resource_listthree.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_listthree)
     end
 
     it "should replace a single value" do
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring wrong.com\n")
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '("example.com" "example.de" "test.com")')
+      resource_listthree.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_listthree)
     end
 
     it "should replace a list of values" do
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring \"example.com\" \"test.com\" \"example.de\"\n")
       resource_listthree.provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'astring:', '("example.com" "example.de" "test.com")')
+      resource_listthree.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_listthree)
     end
   end
 
   describe "ensure is absent" do
-    it "should to nothing if property is already absent" do
+    it "should do nothing if property is already absent" do
       resource_absent.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("\n\n")
       resource_absent.provider.expects(:svccfg).never
+      resource_absent.provider.expects(:svcadm).with(:refresh, fmri).never
       run_in_catalog(resource_absent)
     end
     it "should remove the property if it has a single value" do
       resource_absent.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring wrong.com\n")
       resource_absent.provider.expects(:svccfg).with('-s', fmri, :delprop, prop)
+      resource_absent.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_absent)
     end
 
     it "should remove the property if it has a list of values" do
       resource_absent.provider.expects(:svccfg).with('-s', fmri, :listprop, prop).returns("config/search astring \"example.com\" \"test.com\" \"example.de\"\n")
       resource_absent.provider.expects(:svccfg).with('-s', fmri, :delprop, prop)
+      resource_absent.provider.expects(:svcadm).with(:refresh, fmri)
       run_in_catalog(resource_absent)
     end
   end

--- a/spec/unit/provider/service_config/svccfg_spec.rb
+++ b/spec/unit/provider/service_config/svccfg_spec.rb
@@ -72,6 +72,9 @@ describe Puppet::Type.type(:service_config).provider(:svccfg) do
   end
 
   describe "#ensure=" do
+    before :each do
+      provider.stubs(:svcadm)
+    end
 
     describe "and type is astring" do
       before :each do
@@ -144,6 +147,14 @@ describe Puppet::Type.type(:service_config).provider(:svccfg) do
         provider.expects(:svccfg).with('-s', fmri, :setprop, prop, '=', 'integer:', '(500 600)')
         provider.ensure = [ '500', '600' ]
       end
+    end
+  end
+
+  describe "#flush" do
+    it "should refresh the service" do
+      Puppet::Type.type(:service_config).new(title.merge(:type => :integer, :ensure => '10', :provider => provider))
+      provider.expects(:svcadm).with(:refresh,'svc:/system/keymap:default')
+      provider.flush
     end
   end
 end


### PR DESCRIPTION
Most configuration changes needs a refresh of a service and a restart.
While the restart should probably handled by the end user with a
subscribing service resource, calling refresh seems safe.

The refresh also seems to be necessary for changing stuff like timezones
and environment variables as stated in
http://docs.oracle.com/cd/E23824_01/html/E24456/glmwl.html#gllkr
